### PR TITLE
[Feature] Natural Armor for Tortles

### DIFF
--- a/datapack/data/dnd/function/system/applynaturalarmor.mcfunction
+++ b/datapack/data/dnd/function/system/applynaturalarmor.mcfunction
@@ -1,0 +1,3 @@
+item replace entity @s armor.chest with minecraft:light_gray_stained_glass_pane[minecraft:enchantments={binding_curse:1},minecraft:equippable={slot:"chest"},minecraft:item_name="Natural Armor"]
+item replace entity @s armor.legs with minecraft:light_gray_stained_glass_pane[minecraft:enchantments={binding_curse:1},minecraft:equippable={slot:"legs"},minecraft:item_name="Natural Armor"]
+attribute @s minecraft:armor base set 9

--- a/datapack/data/dnd/function/system/reset.mcfunction
+++ b/datapack/data/dnd/function/system/reset.mcfunction
@@ -7,6 +7,7 @@ attribute @s minecraft:luck base reset
 attribute @s safe_fall_distance base reset
 attribute @s submerged_mining_speed base reset
 attribute @s oxygen_bonus base reset
+attribute @s minecraft:armor base reset
 
 # Permanent Effects
 execute as @s[tag=nightVision] run effect clear @s night_vision
@@ -40,6 +41,7 @@ tag @s remove swordBonus
 
 # Misc
 clear @s ender_pearl[lore=[[{"text":"Species bonus"}]]]
+clear @s minecraft:light_gray_stained_glass_pane[minecraft:enchantments={binding_curse:1},minecraft:item_name="Natural Armor"]
 
 # chosenSpecies
 tag @s remove chosenSpecies

--- a/datapack/data/dnd/function/system/tick.mcfunction
+++ b/datapack/data/dnd/function/system/tick.mcfunction
@@ -14,6 +14,8 @@ execute if score global jumpCheat matches 0 as @a[tag=jumpHeightAdded] run funct
 execute if score global stepCheat matches 1 run function dnd:system/stepcheatactivate
 execute if score global stepCheat matches 0 as @a[tag=stepHeightAdded] run function dnd:species/reset
 
+execute as @a[tag=naturalArmor] run function dnd:system/applynaturalarmor
+
 execute as @a[nbt={SelectedItem:{id:"minecraft:wooden_axe"}},tag=axeBonus] run attribute @s minecraft:attack_damage modifier add dnd:extradamage 2 add_value
 execute as @a[nbt={SelectedItem:{id:"minecraft:stone_axe"}},tag=axeBonus] run attribute @s minecraft:attack_damage modifier add dnd:extradamage 2 add_value
 execute as @a[nbt={SelectedItem:{id:"minecraft:iron_axe"}},tag=axeBonus] run attribute @s minecraft:attack_damage modifier add dnd:extradamage 2 add_value


### PR DESCRIPTION
- Tortles get 9 points of natural armor
- Their chest and leg slots are filled with light gray stained glass panes, which have curse of binding.
- Armor adding is handled via the tick function, so even if they die they'll get it the panes back