### PR TITLE
Fixes for 1.3.1

### DIFF
--- a/datapack/data/dnd/function/species/tortle.mcfunction
+++ b/datapack/data/dnd/function/species/tortle.mcfunction
@@ -1,8 +1,3 @@
-function dnd:system/reset
-attribute @s minecraft:movement_speed base set 0.1
-attribute @s minecraft:scale base set 0.94
-attribute @s minecraft:jump_strength base set 0.4128
-attribute @s minecraft:step_height base set 0.6
-attribute @s oxygen_bonus base set 3.0
-tag @s add naturalArmor
-tag @s add chosenSpecies
+execute if items entity @s armor.chest * run say Sorry, you need to remove your chestplate to use this species
+execute if items entity @s armor.legs * run say Sorry, you need to remove your leggings to use this species
+execute unless items entity @s armor.chest * unless items entity @s armor.legs * run function dnd:system/tortle

--- a/datapack/data/dnd/function/system/freepearl.mcfunction
+++ b/datapack/data/dnd/function/system/freepearl.mcfunction
@@ -1,1 +1,1 @@
-give @a[tag=freePearls] ender_pearl[lore=[[{"text":"Species bonus"}]]]
+give @a[tag=freePearls] ender_pearl[lore=["Species bonus"]]

--- a/datapack/data/dnd/function/system/reset.mcfunction
+++ b/datapack/data/dnd/function/system/reset.mcfunction
@@ -40,7 +40,7 @@ execute as @s[tag=swordBonus] run attribute @s minecraft:attack_damage modifier 
 tag @s remove swordBonus
 
 # Misc
-clear @s ender_pearl[lore=[[{"text":"Species bonus"}]]]
+clear @s ender_pearl[lore=["Species bonus"]]
 clear @s minecraft:light_gray_stained_glass_pane[minecraft:enchantments={binding_curse:1},minecraft:item_name="Natural Armor"]
 
 # chosenSpecies

--- a/datapack/data/dnd/function/system/tortle.mcfunction
+++ b/datapack/data/dnd/function/system/tortle.mcfunction
@@ -1,0 +1,8 @@
+function dnd:system/reset
+attribute @s minecraft:movement_speed base set 0.1
+attribute @s minecraft:scale base set 0.94
+attribute @s minecraft:jump_strength base set 0.4128
+attribute @s minecraft:step_height base set 0.6
+attribute @s oxygen_bonus base set 3.0
+tag @s add naturalArmor
+tag @s add chosenSpecies


### PR DESCRIPTION
- [x] The lore for the special ender pearls is redundantly styled #83
- [x] Armor worn by players is destroyed if they switch to the tortle species #81
- [x] The SleepTimer nbt check uses 50s instead of 50 #82