### PR TITLE
[Fix] Fixed broken character in load1

### DIFF
--- a/datapack/data/dnd/function/system/load1.mcfunction
+++ b/datapack/data/dnd/function/system/load1.mcfunction
@@ -1,2 +1,2 @@
 title @a[tag=!chosenSpecies] title ["Choose a Species"]
-title @a[tag=!chosenSpecies] subtitle "/function dnd:species/[species]\nOr /function dnd:menu"
+title @a[tag=!chosenSpecies] subtitle "/function dnd:species/[species] or /function dnd:menu"


### PR DESCRIPTION
Turns out you can't do line breaks in subtitles, forgot to actually test that