### PR TITLE
Proper sunrise function

### DIFF
--- a/datapack/data/dnd/function/system/load.mcfunction
+++ b/datapack/data/dnd/function/system/load.mcfunction
@@ -2,8 +2,6 @@ schedule function dnd:system/load1 20t
 schedule function dnd:system/clearpoison 100t
 schedule function dnd:system/addfireresis 100t
 schedule function dnd:system/clearwither 100t
-schedule function dnd:system/freepearl 24000t
-schedule function dnd:system/resetshifts 24000t
 schedule function dnd:system/checkforskyaccess 5s
 scoreboard objectives add jumpCheat dummy
 scoreboard objectives add time dummy

--- a/datapack/data/dnd/function/system/load.mcfunction
+++ b/datapack/data/dnd/function/system/load.mcfunction
@@ -6,6 +6,7 @@ schedule function dnd:system/freepearl 24000t
 schedule function dnd:system/resetshifts 24000t
 schedule function dnd:system/checkforskyaccess 5s
 scoreboard objectives add jumpCheat dummy
+scoreboard objectives add time dummy
 scoreboard objectives add stepCheat dummy
 scoreboard objectives add timeShifted dummy
 scoreboard objectives add shiftsToday dummy

--- a/datapack/data/dnd/function/system/sunrise.mcfunction
+++ b/datapack/data/dnd/function/system/sunrise.mcfunction
@@ -1,0 +1,1 @@
+say hello

--- a/datapack/data/dnd/function/system/sunrise.mcfunction
+++ b/datapack/data/dnd/function/system/sunrise.mcfunction
@@ -1,1 +1,2 @@
-say hello
+function dnd:system/freepearl
+function dnd:system/resetshifts

--- a/datapack/data/dnd/function/system/tick.mcfunction
+++ b/datapack/data/dnd/function/system/tick.mcfunction
@@ -16,6 +16,10 @@ execute if score global stepCheat matches 0 as @a[tag=stepHeightAdded] run funct
 
 execute as @a[tag=naturalArmor] run function dnd:system/applynaturalarmor
 
+execute store result score #time time run time query daytime
+
+execute if score #time time matches 23500 run function dnd:system/sunrise
+
 execute as @a[nbt={SelectedItem:{id:"minecraft:wooden_axe"}},tag=axeBonus] run attribute @s minecraft:attack_damage modifier add dnd:extradamage 2 add_value
 execute as @a[nbt={SelectedItem:{id:"minecraft:stone_axe"}},tag=axeBonus] run attribute @s minecraft:attack_damage modifier add dnd:extradamage 2 add_value
 execute as @a[nbt={SelectedItem:{id:"minecraft:iron_axe"}},tag=axeBonus] run attribute @s minecraft:attack_damage modifier add dnd:extradamage 2 add_value


### PR DESCRIPTION
Up until now, the sunrise "detection" was really just 24000 ticks after the pack was last loaded, which was pretty inefficient and would almost never line-up with the actual sunrise.

This pull request changes that:
- Current time is detected using a score
  - This will be useful for many things in the future
- At 23500, the `sunrise` function is called
  - This in turn calls the `freepearl` and `resetshifts` functions